### PR TITLE
Make TypeInfo immutable and use cached type infos

### DIFF
--- a/Stack/Opc.Ua.Core/Types/Constants/Attributes.Helpers.cs
+++ b/Stack/Opc.Ua.Core/Types/Constants/Attributes.Helpers.cs
@@ -17,6 +17,10 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+
 namespace Opc.Ua
 {
     /// <summary>
@@ -396,8 +400,11 @@ namespace Opc.Ua
             {
                 keyValuePairs.Add((uint)field.GetValue(typeof(Attributes)), field.Name);
             }
-
+#if NET8_0_OR_GREATER
+            return keyValuePairs.ToFrozenDictionary().AsReadOnly();
+#else
             return new ReadOnlyDictionary<uint, string>(keyValuePairs);
+#endif
         }
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Types/Constants/StatusCodes.Helpers.cs
+++ b/Stack/Opc.Ua.Core/Types/Constants/StatusCodes.Helpers.cs
@@ -17,6 +17,10 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+
 namespace Opc.Ua
 {
     /// <summary>
@@ -78,8 +82,11 @@ namespace Opc.Ua
             {
                 keyValuePairs.Add((uint)field.GetValue(typeof(StatusCodes)), field.Name);
             }
-
+#if NET8_0_OR_GREATER
+            return keyValuePairs.ToFrozenDictionary().AsReadOnly();
+#else
             return new ReadOnlyDictionary<uint, string>(keyValuePairs);
+#endif
         }
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/BinaryDecoder.cs
@@ -2327,7 +2327,7 @@ namespace Opc.Ua
 
                         if (dimensions.Count == 1)
                         {
-                            value = new Variant(array, new TypeInfo(builtInType, 1));
+                            value = new Variant(array, TypeInfo.CreateArray(builtInType));
                         }
                         else
                         {
@@ -2336,7 +2336,7 @@ namespace Opc.Ua
                     }
                     else
                     {
-                        value = new Variant(array, new TypeInfo(builtInType, 1));
+                        value = new Variant(array, TypeInfo.CreateArray(builtInType));
                     }
                 }
             }

--- a/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/JsonEncoder.cs
@@ -3018,7 +3018,7 @@ namespace Opc.Ua
                     {
                         m_writer.Write(s_comma);
                     }
-                    WriteVariantContents(copy, new TypeInfo(typeInfo.BuiltInType, 1));
+                    WriteVariantContents(copy, TypeInfo.CreateArray(typeInfo.BuiltInType));
                     index += arrayLen;
                 }
                 else

--- a/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
+++ b/Stack/Opc.Ua.Core/Types/Encoders/XmlEncoder.cs
@@ -2165,7 +2165,7 @@ namespace Opc.Ua
                 if (value != null)
                 {
                     m_writer.WriteStartElement("Elements", Namespaces.OpcUaXsd);
-                    WriteVariantContents(value.Elements, new TypeInfo(value.TypeInfo.BuiltInType, ValueRanks.OneDimension));
+                    WriteVariantContents(value.Elements, TypeInfo.CreateArray(value.TypeInfo.BuiltInType));
                     m_writer.WriteEndElement();
 
                     WriteInt32Array("Dimensions", value.Dimensions);

--- a/Stack/Opc.Ua.Core/Types/Generated/Opc.Ua.StatusCodes.cs
+++ b/Stack/Opc.Ua.Core/Types/Generated/Opc.Ua.StatusCodes.cs
@@ -542,7 +542,7 @@ namespace Opc.Ua
         /// <summary>
         /// The semaphore file specified by the client is not valid.
         /// </summary>
-        public const uint BadSempahoreFileMissing = 0x80520000;
+        public const uint BadSemaphoreFileMissing = 0x80520000;
 
         /// <summary>
         /// The security token request type is not valid.

--- a/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/DataGenerator.cs
@@ -503,7 +503,7 @@ namespace Opc.Ua.Test
         {
             Array array = GetRandomArray(builtInType, useBoundaryValues, length, fixedLength);
             Variant[] variants = new Variant[array.Length];
-            TypeInfo typeInfo = new TypeInfo(builtInType, ValueRanks.Scalar);
+            TypeInfo typeInfo = TypeInfo.CreateScalar(builtInType);
 
             for (int ii = 0; ii < variants.Length; ii++)
             {

--- a/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/BuiltIn/BuiltInTests.cs
@@ -112,7 +112,7 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             object randomData = DataGenerator.GetRandom(builtInType);
             Variant variant1 = new Variant(randomData);
             Assert.AreEqual(builtInType, variant1.TypeInfo.BuiltInType);
-            Variant variant2 = new Variant(randomData, new TypeInfo(builtInType, ValueRanks.Scalar));
+            Variant variant2 = new Variant(randomData, TypeInfo.CreateScalar(builtInType));
             Assert.AreEqual(builtInType, variant2.TypeInfo.BuiltInType);
             Variant variant3 = new Variant(variant2);
             Assert.AreEqual(builtInType, variant3.TypeInfo.BuiltInType);
@@ -139,7 +139,7 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
             {
                 Assert.AreEqual(builtInType, variant1.TypeInfo.BuiltInType);
             }
-            Variant variant2 = new Variant(randomData, new TypeInfo(builtInType, ValueRanks.OneDimension));
+            Variant variant2 = new Variant(randomData, TypeInfo.CreateArray(builtInType));
             Assert.AreEqual(builtInType, variant2.TypeInfo.BuiltInType);
         }
 
@@ -162,16 +162,16 @@ namespace Opc.Ua.Core.Tests.Types.BuiltIn
         {
             // Enum Scalar
             Variant variant0 = new Variant(DayOfWeek.Monday);
-            Variant variant1 = new Variant(DayOfWeek.Monday, new TypeInfo(BuiltInType.Enumeration, ValueRanks.Scalar));
+            Variant variant1 = new Variant(DayOfWeek.Monday, TypeInfo.Scalars.Enumeration);
 
             // Enum array
             DayOfWeek[] days = new DayOfWeek[] { DayOfWeek.Monday, DayOfWeek.Tuesday };
-            Variant variant2 = new Variant(days, new TypeInfo(BuiltInType.Enumeration, ValueRanks.OneDimension));
+            Variant variant2 = new Variant(days, TypeInfo.Arrays.Enumeration);
             Variant variant3 = new Variant(days);
 
             // Enum 2-dim Array
             DayOfWeek[,] daysdays = new DayOfWeek[,] { { DayOfWeek.Monday, DayOfWeek.Tuesday }, { DayOfWeek.Monday, DayOfWeek.Tuesday } };
-            Variant variant5 = new Variant(daysdays, new TypeInfo(BuiltInType.Enumeration, ValueRanks.TwoDimensions));
+            Variant variant5 = new Variant(daysdays, TypeInfo.Create(BuiltInType.Enumeration, ValueRanks.TwoDimensions));
 
             // not supported
             // Variant variant6 = new Variant(daysdays);

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -393,7 +393,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                 new Variant(new string[] {"1", "2", "3", "4", "5" }),
                 //TODO: works as expected, but the expected need to be tweaked for the Int32 result
                 //new Variant(new TestEnumType[] { TestEnumType.One, TestEnumType.Two, TestEnumType.Hundred }),
-                new Variant(new Int32[] { 2, 3, 10 }, new TypeInfo(BuiltInType.Enumeration, 1))
+                new Variant(new Int32[] { 2, 3, 10 }, TypeInfo.Arrays.Enumeration)
             };
             EncodeDecodeDataValue(encoderType, jsonEncodingType, BuiltInType.Variant, MemoryStreamType.ArraySegmentStream, variant);
         }
@@ -526,7 +526,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
             Assume.That(builtInType != BuiltInType.Null);
             int arrayDimension = RandomSource.NextInt32(99) + 1;
             Array randomData = DataGenerator.GetRandomArray(builtInType, false, arrayDimension, true);
-            var variant = new Variant(randomData, new TypeInfo(builtInType, 1));
+            var variant = new Variant(randomData, TypeInfo.CreateArray(builtInType));
             EncodeDecodeDataValue(encoderType, jsonEncodingType, BuiltInType.Variant, MemoryStreamType.RecyclableMemoryStream, variant);
         }
 


### PR DESCRIPTION
## Proposed changes

In order to prepare for lesser allocations, make TypeInfo immutable and use cached type infos.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
