### PR TITLE
Fix a special case for reconnect when the certificate/endpoint has changed

### DIFF
--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -1065,6 +1065,9 @@ namespace Quickstarts
                 };
                 session.AddSubscription(subscription);
 
+                // hook state changed event handler
+                subscription.StateChanged += OnSubscriptionStateChanged;
+
                 // Create the subscription on Server side
                 await subscription.CreateAsync().ConfigureAwait(false);
                 m_output.WriteLine("New Subscription created with SubscriptionId = {0}.", subscription.Id);
@@ -1178,7 +1181,18 @@ namespace Quickstarts
         }
 
         /// <summary>
-        /// Handle DataChange notifications from Server
+        /// A suscription callback sample.
+        /// </summary>
+        private void OnSubscriptionStateChanged(Subscription subscription, SubscriptionStateChangedEventArgs newState)
+        {
+            if ((newState.Status & ~SubscriptionChangeMask.ItemsAdded) != 0)
+            {
+                m_output.WriteLine("Subscription Status Changed {0}", newState.Status.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Handle DataChange notifications from Server.
         /// </summary>
         private void OnMonitoredItemNotification(MonitoredItem monitoredItem, MonitoredItemNotificationEventArgs e)
         {

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -672,9 +672,9 @@ namespace Opc.Ua.Client
                 // first try to match single registrations
                 foreach (var registration in m_registrations.Where(r => (r.ReverseConnectStrategy & ReverseConnectStrategy.Any) == 0))
                 {
-                    if (registration.EndpointUrl.Scheme.Equals(e.EndpointUrl.Scheme, StringComparison.InvariantCulture) &&
-                       (registration.ServerUri == e.ServerUri ||
-                        registration.EndpointUrl.Authority.Equals(e.EndpointUrl.Authority, StringComparison.InvariantCulture)))
+                    if (registration.EndpointUrl.Scheme.Equals(e.EndpointUrl.Scheme, StringComparison.Ordinal) &&
+                           (registration.ServerUri.Equals(e.ServerUri, StringComparison.Ordinal) ||
+                            registration.EndpointUrl.Authority.Equals(e.EndpointUrl.Authority, StringComparison.OrdinalIgnoreCase)))
                     {
                         callbackRegistration = registration;
                         e.Accepted = true;
@@ -689,7 +689,7 @@ namespace Opc.Ua.Client
                 {
                     foreach (var registration in m_registrations.Where(r => (r.ReverseConnectStrategy & ReverseConnectStrategy.Any) != 0))
                     {
-                        if (registration.EndpointUrl.Scheme.Equals(e.EndpointUrl.Scheme, StringComparison.InvariantCulture))
+                        if (registration.EndpointUrl.Scheme.Equals(e.EndpointUrl.Scheme, StringComparison.Ordinal))
                         {
                             callbackRegistration = registration;
                             e.Accepted = true;

--- a/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
+++ b/Libraries/Opc.Ua.Client/ReverseConnectManager.cs
@@ -673,7 +673,7 @@ namespace Opc.Ua.Client
                 foreach (var registration in m_registrations.Where(r => (r.ReverseConnectStrategy & ReverseConnectStrategy.Any) == 0))
                 {
                     if (registration.EndpointUrl.Scheme.Equals(e.EndpointUrl.Scheme, StringComparison.Ordinal) &&
-                           (registration.ServerUri.Equals(e.ServerUri, StringComparison.Ordinal) ||
+                           (registration.ServerUri?.Equals(e.ServerUri, StringComparison.Ordinal) == true ||
                             registration.EndpointUrl.Authority.Equals(e.EndpointUrl.Authority, StringComparison.OrdinalIgnoreCase)))
                     {
                         callbackRegistration = registration;

--- a/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
+++ b/Libraries/Opc.Ua.Client/Session/SessionReconnectHandler.cs
@@ -499,11 +499,11 @@ namespace Opc.Ua.Client
             }
             catch (ServiceResultException sre)
             {
-                if (sre.InnerResult?.StatusCode == StatusCodes.BadSecurityChecksFailed ||
+                if (sre.InnerResult?.StatusCode == StatusCodes.BadSecureChannelClosed ||
+                    sre.InnerResult?.StatusCode == StatusCodes.BadSecurityChecksFailed ||
                     sre.InnerResult?.StatusCode == StatusCodes.BadCertificateInvalid)
                 {
-                    // schedule endpoint update and retry
-                    m_updateFromServer = true;
+                    // schedule a fast endpoint update and retry
                     if (m_maxReconnectPeriod > MinReconnectPeriod &&
                         m_reconnectPeriod >= m_maxReconnectPeriod)
                     {
@@ -513,8 +513,9 @@ namespace Opc.Ua.Client
                 }
                 else
                 {
-                    Utils.LogError("Could not reconnect the Session. {0}", Redact.Create(sre));
+                    Utils.LogError("Could not reconnect the Session. Request endpoint update from server. {0}", Redact.Create(sre));
                 }
+                m_updateFromServer = true;
                 return false;
             }
             catch (Exception exception)

--- a/Stack/Opc.Ua.Core/Stack/Configuration/EndpointDescription.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/EndpointDescription.cs
@@ -93,11 +93,14 @@ namespace Opc.Ua
         /// </summary>
         public UserTokenPolicy FindUserTokenPolicy(string policyId)
         {
-            foreach (UserTokenPolicy policy in m_userIdentityTokens)
+            if (!string.IsNullOrEmpty(policyId))
             {
-                if (policy.PolicyId == policyId)
+                foreach (UserTokenPolicy policy in m_userIdentityTokens)
                 {
-                    return policy;
+                    if (policyId.Equals(policy.PolicyId, StringComparison.Ordinal))
+                    {
+                        return policy;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

When server is restarted with a new certificate, the reconnect handler was stuck in an endless loop.
Add robustness to the StateChanged callback where an exception could prevent a client from reconnecting. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
