### PR TITLE
Packagemanager

### DIFF
--- a/Applications/ConsoleReferenceClient/ClientSamples.cs
+++ b/Applications/ConsoleReferenceClient/ClientSamples.cs
@@ -181,10 +181,7 @@ namespace Quickstarts
                 m_output.WriteLine("Writing nodes...");
 
                 // Call Write Service
-                session.Write(null,
-                                nodesToWrite,
-                                out results,
-                                out diagnosticInfos);
+                session.Write(null, nodesToWrite, out results, out diagnosticInfos);
 
                 // Validate the response
                 m_validateResponse(results, nodesToWrite);
@@ -1007,7 +1004,7 @@ namespace Quickstarts
                 }
                 catch (ServiceResultException sre) when (sre.StatusCode == StatusCodes.BadEncodingLimitsExceeded)
                 {
-                    m_output.WriteLine("Retry to read the values due to error:", sre.Message);
+                    m_output.WriteLine("Retry to read the values due to error: {0}", sre.Message);
                     retrySingleRead = !retrySingleRead;
                 }
             } while (retrySingleRead);

--- a/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
+++ b/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
@@ -20,16 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Expressions" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Applications/ConsoleReferencePublisher/ConsoleReferencePublisher.csproj
+++ b/Applications/ConsoleReferencePublisher/ConsoleReferencePublisher.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\..\Stack\Opc.Ua.Bindings.Https\Opc.Ua.Bindings.Https.csproj" />
   </ItemGroup>
 
-
   <ItemGroup>
     <ProjectReference Include="..\..\Stack\Opc.Ua.Core\Opc.Ua.Core.csproj" />
     <ProjectReference Include="..\..\Libraries\Opc.Ua.Configuration\Opc.Ua.Configuration.csproj" />
@@ -29,16 +28,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.4" />
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Expressions" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Applications/ConsoleReferenceSubscriber/ConsoleReferenceSubscriber.csproj
+++ b/Applications/ConsoleReferenceSubscriber/ConsoleReferenceSubscriber.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,49 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="EmbedIO" Version="3.5.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MQTTnet" Version="4.3.7.1207" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit.Console" Version="3.20.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="SharpFuzz" Version="2.2.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.2" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.5" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.5" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageVersion Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/Fuzzing/Encoders/Fuzz.Tests/Opc.Ua.Encoders.Fuzz.Tests.csproj
+++ b/Fuzzing/Encoders/Fuzz.Tests/Opc.Ua.Encoders.Fuzz.Tests.csproj
@@ -20,20 +20,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpFuzz" Version="2.2.0" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="SharpFuzz" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fuzzing/Encoders/Fuzz.Tools/Encoders.Fuzz.Tools.csproj
+++ b/Fuzzing/Encoders/Fuzz.Tools/Encoders.Fuzz.Tools.csproj
@@ -22,15 +22,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpFuzz" Version="2.2.0" />
-    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="SharpFuzz" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Expressions" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fuzzing/Encoders/Fuzz/Encoders.Fuzz.csproj
+++ b/Fuzzing/Encoders/Fuzz/Encoders.Fuzz.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpFuzz" Version="2.2.0" />
+    <PackageReference Include="SharpFuzz" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/Opc.Ua.Client/NodeCache/NodeCacheAsync.cs
+++ b/Libraries/Opc.Ua.Client/NodeCache/NodeCacheAsync.cs
@@ -385,7 +385,7 @@ namespace Opc.Ua.Client
             bool includeSubtypes,
             CancellationToken ct)
         {
-            IList<INode> targets = new List<INode>();
+            var targets = new List<INode>();
             if (nodeIds.Count == 0 || referenceTypeIds.Count == 0)
             {
                 return targets;

--- a/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
+++ b/Libraries/Opc.Ua.Client/Subscription/Subscription.cs
@@ -2336,6 +2336,7 @@ namespace Opc.Ua.Client
                                 {
                                     datachange.PublishTime = message.PublishTime;
                                     datachange.SequenceNumber = message.SequenceNumber;
+                                    datachange.MoreNotifications = message.MoreNotifications;
 
                                     noNotificationsReceived += datachange.MonitoredItems.Count;
 
@@ -2353,6 +2354,7 @@ namespace Opc.Ua.Client
                                 {
                                     events.PublishTime = message.PublishTime;
                                     events.SequenceNumber = message.SequenceNumber;
+                                    events.MoreNotifications = message.MoreNotifications;
 
                                     noNotificationsReceived += events.Events.Count;
 
@@ -2610,12 +2612,13 @@ namespace Opc.Ua.Client
         {
             lock (m_cache)
             {
-                itemsToModify = new List<MonitoredItem>();
-                var updatedMonitoredItems = new Dictionary<uint, MonitoredItem>();
+                int count = clientHandles.Count;
+                itemsToModify = new List<MonitoredItem>(count);
+                var updatedMonitoredItems = new Dictionary<uint, MonitoredItem>(count);
                 foreach (MonitoredItem monitoredItem in m_monitoredItems.Values)
                 {
                     var index = serverHandles.FindIndex(handle => handle == monitoredItem.Status.Id);
-                    if (index >= 0 && index < clientHandles.Count)
+                    if (index >= 0 && index < count)
                     {
                         var clientHandle = clientHandles[index];
                         updatedMonitoredItems[clientHandle] = monitoredItem;

--- a/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj
+++ b/Libraries/Opc.Ua.Gds.Server.Common/Opc.Ua.Gds.Server.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
+++ b/Libraries/Opc.Ua.PubSub/Opc.Ua.PubSub.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
  
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
+    <PackageReference Include="MQTTnet" />
+    <PackageReference Include="System.Net.NetworkInformation" />
   </ItemGroup>
 
   <Target Name="GetPackagingOutputs" />

--- a/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj
+++ b/Libraries/Opc.Ua.Security.Certificates/Opc.Ua.Security.Certificates.csproj
@@ -18,12 +18,12 @@
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net462'">
       <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+        <PackageReference Include="BouncyCastle.Cryptography" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+        <PackageReference Include="BouncyCastle.Cryptography" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -45,18 +45,18 @@
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
       <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
-        <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
+        <PackageReference Include="BouncyCastle.Cryptography" />
+        <PackageReference Include="System.Formats.Asn1" VersionOverride="8.0.2" />
       </ItemGroup>
     </When>
-    <When Condition="'$(TargetFramework)' == 'net9.0'">
+    <When Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0'">
       <ItemGroup>
-        <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
+        <PackageReference Include="System.Formats.Asn1" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
+        <PackageReference Include="System.Formats.Asn1" VersionOverride="8.0.2" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/CertificateBuilder.cs
@@ -46,6 +46,7 @@ using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
 
 namespace Opc.Ua.Security.Certificates
 {
@@ -314,7 +315,7 @@ namespace Opc.Ua.Security.Certificates
             {
                 // Subject key identifier
                 cg.AddExtension(Org.BouncyCastle.Asn1.X509.X509Extensions.SubjectKeyIdentifier.Id, false,
-                new SubjectKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectPublicKey)));
+                    X509ExtensionUtilities.CreateSubjectKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectPublicKey)));
             }
 
             // Basic constraints
@@ -353,8 +354,10 @@ namespace Opc.Ua.Security.Certificates
             if (X509Extensions.FindExtension<X509AuthorityKeyIdentifierExtension>(m_extensions) == null)
             {
                 cg.AddExtension(Org.BouncyCastle.Asn1.X509.X509Extensions.AuthorityKeyIdentifier.Id, false,
-                new AuthorityKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerPublicKey),
-                    new GeneralNames(new GeneralName(m_issuerIssuerAKI)), issuerSerialNumber));
+                    X509ExtensionUtilities.CreateAuthorityKeyIdentifier(
+                        issuerPublicKey,
+                        new GeneralNames(new GeneralName(m_issuerIssuerAKI)),
+                        issuerSerialNumber));
             }
 
             if (!m_isCA)

--- a/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/PEMReader.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/Org.BouncyCastle/PEMReader.cs
@@ -55,7 +55,7 @@ namespace Opc.Ua.Security.Certificates
             Org.BouncyCastle.OpenSsl.PemReader pemReader;
             using (var pemStreamReader = new StreamReader(new MemoryStream(pemDataBlob), Encoding.UTF8, true))
             {
-                if (password == null || password.Length == 0)
+                if (password.IsEmpty || password.IsWhiteSpace())
                 {
                     pemReader = new Org.BouncyCastle.OpenSsl.PemReader(pemStreamReader);
                 }

--- a/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/X509Crl/X509Crl.cs
@@ -335,7 +335,7 @@ namespace Opc.Ua.Security.Certificates
                     m_decoded = true;
                     return;
                 }
-                throw new CryptographicException("The CRL contains ivalid data.");
+                throw new CryptographicException("The CRL contains invalid data.");
             }
             catch (AsnContentException ace)
             {

--- a/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
+++ b/Libraries/Opc.Ua.Server/Configuration/ConfigurationNodeManager.cs
@@ -699,7 +699,7 @@ namespace Opc.Ua.Server
             }
             else
             {
-                certificateTypeIds = new NodeId[0];
+                certificateTypeIds = Array.Empty<NodeId>();
                 certificates = Array.Empty<byte[]>();
             }
 

--- a/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj
+++ b/Stack/Opc.Ua.Bindings.Https/Opc.Ua.Bindings.Https.csproj
@@ -22,11 +22,11 @@
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
       <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
+        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
+        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" />
+        <PackageReference Include="Microsoft.AspNetCore.Http" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 
   <Target Name="GetPackagingOutputs" />

--- a/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
+++ b/Stack/Opc.Ua.Core/Opc.Ua.Core.csproj
@@ -45,44 +45,44 @@
          use latest versions only on .NET 5/6/7/8, otherwise 3.1.x -->
     <When Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
       <ItemGroup>
-        <PackageReference Include="System.Memory" Version="4.6.3" />
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
+        <PackageReference Include="System.Memory" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="6.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="3.1.32" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
       <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="6.0.4" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net8.0'">
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
       </ItemGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
       <ItemGroup>
-        <PackageReference Include="System.Memory" Version="4.6.3" />
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+        <PackageReference Include="System.Memory" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="6.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="6.0.4" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net462'">

--- a/Stack/Opc.Ua.Core/Stack/Buffers/ArrayPoolBufferWriter{T}.cs
+++ b/Stack/Opc.Ua.Core/Stack/Buffers/ArrayPoolBufferWriter{T}.cs
@@ -139,7 +139,6 @@ namespace Opc.Ua.Buffers
                 throw new ArgumentOutOfRangeException(nameof(sizeHint), $"{nameof(sizeHint)} must be non-negative.");
             }
 
-
             int remainingSpace = CheckAndAllocateBuffer(sizeHint);
             return _currentBuffer.AsSpan(_offset, remainingSpace);
         }

--- a/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
+++ b/Stack/Opc.Ua.Core/Stack/Types/UserIdentityToken.cs
@@ -14,6 +14,7 @@ using System;
 using System.Text;
 using System.Security.Cryptography.X509Certificates;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Opc.Ua
 {
@@ -81,7 +82,7 @@ namespace Opc.Ua
         /// <summary>
         /// The decrypted password associated with the token.
         /// </summary>
-        [IgnoreDataMember]
+        [IgnoreDataMember, JsonIgnore]
         public byte[] DecryptedPassword
         {
             get { return m_decryptedPassword; }
@@ -297,18 +298,6 @@ namespace Opc.Ua
     /// </summary>
     public partial class IssuedIdentityToken
     {
-        /// <summary>
-        /// Ensure the finalizer erases the unencrypted data.
-        /// </summary>
-        ~IssuedIdentityToken()
-        {
-            if (m_decryptedTokenData != null)
-            {
-                Array.Clear(m_decryptedTokenData, 0, m_decryptedTokenData.Length);
-                m_decryptedTokenData = null;
-            }
-        }
-
         #region Public Properties
         /// <summary>
         /// The type of issued token.
@@ -322,34 +311,11 @@ namespace Opc.Ua
         /// <summary>
         /// The decrypted password associated with the token.
         /// </summary>
-        /// <remarks>
-        /// Internally always creates a deep copy on get and set, so that the user
-        /// can clear the token data after using or setting it.
-        /// </remarks>
+        [IgnoreDataMember, JsonIgnore]
         public byte[] DecryptedTokenData
         {
-            get
-            {
-                if (m_decryptedTokenData != null)
-                {
-                    var result = new byte[m_decryptedTokenData.Length];
-                    Array.Copy(m_decryptedTokenData, result, m_decryptedTokenData.Length);
-                    return result;
-                }
-                return null;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    m_decryptedTokenData = new byte[value.Length];
-                    Array.Copy(value, m_decryptedTokenData, value.Length);
-                }
-                else
-                {
-                    m_decryptedTokenData = null;
-                }
-            }
+            get { return m_decryptedTokenData; }
+            set { m_decryptedTokenData = value; }
         }
         #endregion
 

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/ExtensionObject.cs
@@ -418,6 +418,11 @@ namespace Opc.Ua
                     m_encoding = ExtensionObjectEncoding.Xml;
                 }
 
+                else if (m_body is Newtonsoft.Json.Linq.JObject)
+                {
+                    m_encoding = ExtensionObjectEncoding.Json;
+                }
+
                 else
                 {
                     throw new ServiceResultException(

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
@@ -333,9 +333,7 @@ namespace Opc.Ua
                     // prepend the namespace index if the name contains a colon.
                     if (m_name != null)
                     {
-                        int index = m_name.IndexOf(':');
-
-                        if (index != -1)
+                        if (m_name.Contains(':'))
                         {
                             builder.Append("0:");
                         }

--- a/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
+++ b/Stack/Opc.Ua.Core/Types/BuiltIn/QualifiedName.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;

--- a/Tests/Opc.Ua.Client.ComplexTypes.Tests/Opc.Ua.Client.ComplexTypes.Tests.csproj
+++ b/Tests/Opc.Ua.Client.ComplexTypes.Tests/Opc.Ua.Client.ComplexTypes.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Opc.Ua.Client.Tests/Opc.Ua.Client.Tests.csproj
+++ b/Tests/Opc.Ua.Client.Tests/Opc.Ua.Client.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
+++ b/Tests/Opc.Ua.Configuration.Tests/ApplicationInstanceTests.cs
@@ -501,7 +501,7 @@ namespace Opc.Ua.Configuration.Tests
                     await issuerCert.AddToStoreAsync(
                         applicationInstance.ApplicationConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StoreType,
                         applicationInstance.ApplicationConfiguration.SecurityConfiguration.TrustedIssuerCertificates.StorePath
-                        );
+                        ).ConfigureAwait(false);
                 }
             }
 
@@ -513,7 +513,7 @@ namespace Opc.Ua.Configuration.Tests
                 await testCert.AddToStoreAsync(
                     applicationCertificate.StoreType,
                     applicationCertificate.StorePath
-                    );
+                    ).ConfigureAwait(false);
                 publicKey = X509CertificateLoader.LoadCertificate(testCert.RawData);
             }
 

--- a/Tests/Opc.Ua.Configuration.Tests/Opc.Ua.Configuration.Tests.csproj
+++ b/Tests/Opc.Ua.Configuration.Tests/Opc.Ua.Configuration.Tests.csproj
@@ -8,21 +8,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,4 +40,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
+++ b/Tests/Opc.Ua.Core.Tests/Opc.Ua.Core.Tests.csproj
@@ -9,22 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 
   <Choose>
@@ -44,7 +44,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SignAssembly)' != 'true'">
-    <PackageReference Include="EmbedIO" Version="3.5.2" />
+    <PackageReference Include="EmbedIO" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Encoders/EncoderTests.cs
@@ -936,9 +936,7 @@ namespace Opc.Ua.Core.Tests.Types.Encoders
                         {
                             // check such matrix cannot be initialized when encoded into Json format
                             // the exception is thrown while trying to WriteStructureMatrix into the arrray 
-                            Assert.Throws(
-                                typeof(ServiceResultException),
-                                () => {
+                            NUnit.Framework.Assert.Throws<ServiceResultException>(() => {
                                     encoder.WriteArray(builtInType.ToString(), matrix, matrix.TypeInfo.ValueRank, builtInType);
                                 });
                             return;

--- a/Tests/Opc.Ua.Gds.Tests/Opc.Ua.Gds.Tests.csproj
+++ b/Tests/Opc.Ua.Gds.Tests/Opc.Ua.Gds.Tests.csproj
@@ -12,15 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Opc.Ua.PubSub.Tests/Opc.Ua.PubSub.Tests.csproj
+++ b/Tests/Opc.Ua.PubSub.Tests/Opc.Ua.PubSub.Tests.csproj
@@ -8,21 +8,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Moq" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
   
   <ItemGroup>
@@ -34,11 +34,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
+++ b/Tests/Opc.Ua.Security.Certificates.Tests/Opc.Ua.Security.Certificates.Tests.csproj
@@ -17,25 +17,25 @@
         <DefineConstants>$(DefineConstants);ECC_SUPPORT</DefineConstants>
       </PropertyGroup>
       <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+        <PackageReference Include="System.Security.Cryptography.Cng" />
       </ItemGroup>
     </Otherwise>
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
+++ b/Tests/Opc.Ua.Server.Tests/Opc.Ua.Server.Tests.csproj
@@ -8,20 +8,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Console" Version="3.20.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Console" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Tests/customtest.bat
+++ b/Tests/customtest.bat
@@ -2,17 +2,17 @@
 setlocal enabledelayedexpansion
 
 echo This script is used to run custom platform tests for the UA Core Library
-echo Supported parameters: net462, netstandard2.0, netstandard2.1, net472, net48, net6.0, net8.0, net 9.0
+echo Supported parameters: net462, netstandard2.0, netstandard2.1, net472, net48, net8.0, net 9.0
 
 REM Check if the target framework parameter is provided
 if "%1"=="" (
     echo Usage: %0 [TargetFramework]
-    echo Allowed values for TargetFramework: net462, netstandard2.0, netstandard2.1, net472, net48, net6.0, net8.0, net9.0, default
+    echo Allowed values for TargetFramework: net462, netstandard2.0, netstandard2.1, net472, net48, net8.0, net9.0, default
     goto :eof
 )
 
 REM Check if the provided TargetFramework is valid
-set "validFrameworks= default net462 net472 netstandard2.0 netstandard2.1 net48 net6.0 net8.0 net9.0 "
+set "validFrameworks= default net462 net472 netstandard2.0 netstandard2.1 net48 net8.0 net9.0 "
 if "!validFrameworks: %1 =!"=="%validFrameworks%" (
     echo Invalid TargetFramework specified. Allowed values are: default, net462, net472 netstandard2.0, netstandard2.1, net48, net6.0, net8.0, net9.0
     goto :eof

--- a/common.props
+++ b/common.props
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NBGV_PublicRelease)' != ''">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- Deterministic build is currently not supported for code coverage tests. -->

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup Condition="'$(TF_BUILD)' != 'true' AND '$(GITHUB_ACTIONS)' != 'true' AND '$(CODEQL_RUNNER)' == '' AND '$(Dockerbuild)' != 'true'">
     <!-- Note: Keep Version 3.7.115, it is known working for 4 digit versioning -->
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
+    <PackageReference Include="Nerdbank.GitVersioning">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -25,4 +25,3 @@
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
   </PropertyGroup>
 </Project>
-


### PR DESCRIPTION
## Proposed changes

This pull request introduces the NuGet [Central Package Management](https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fnuget%2Fconsume-packages%2FCentral-Package-Management) feature to streamline dependency management. Key benefits and changes include:
o	Centralized Version Management: All NuGet package versions are now managed centrally in the Directory.Packages.props file. This ensures consistency across all projects in the repository. 
o	Simplified Project Files: The individual project files are simplified, as they no longer need to specify version numbers for NuGet packages. This change reduces duplication and the potential for version conflicts. 
o	Ease of Updating Dependencies: Updating a package version is now a matter of changing it in one place, making the process of keeping dependencies up-to-date more straightforward and less error-prone.

By implementing Central Package Versioning, we're taking a significant step towards more efficient and reliable dependency management. This change will be particularly beneficial to assist with tools like Dependabot. These tools automate dependency updates, and having a centralized versioning system significantly enhances their effectiveness, ensuring a smooth and consistent update process.
