### PR TITLE
Remove trace event legacy logger callback and trace file writer

### DIFF
--- a/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
+++ b/Applications/ConsoleReferenceClient/ConsoleReferenceClient.csproj
@@ -7,7 +7,7 @@
     <PackageId>ConsoleReferenceClient</PackageId>
     <Company>OPC Foundation</Company>
     <Description>.NET Console Reference Client</Description>
-    <Copyright>Copyright © 2004-2024 OPC Foundation, Inc</Copyright>
+    <Copyright>Copyright © 2004-2025 OPC Foundation, Inc</Copyright>
     <RootNamespace>Quickstarts.ConsoleReferenceClient</RootNamespace>
   </PropertyGroup>
 

--- a/Applications/ConsoleReferencePublisher/Program.cs
+++ b/Applications/ConsoleReferencePublisher/Program.cs
@@ -758,11 +758,13 @@ namespace Quickstarts.ConsoleReferencePublisher
         /// </summary>
         private static void InitializeLog()
         {
+#if TRACEEVENTLOGGER
             // Initialize logger
             Utils.SetTraceLog("%CommonApplicationData%\\OPC Foundation\\Logs\\Quickstarts.ConsoleReferencePublisher.log.txt", true);
             Utils.SetTraceMask(Utils.TraceMasks.Error);
             Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
+#endif
         }
-        #endregion
+#endregion
     }
 }

--- a/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
+++ b/Applications/ConsoleReferenceServer/ConsoleReferenceServer.csproj
@@ -7,7 +7,7 @@
     <PackageId>ConsoleReferenceServer</PackageId>
     <Company>OPC Foundation</Company>
     <Description>.NET Console Reference Server</Description>
-    <Copyright>Copyright © 2004-2024 OPC Foundation, Inc</Copyright>
+    <Copyright>Copyright © 2004-2025 OPC Foundation, Inc</Copyright>
     <RootNamespace>Quickstarts</RootNamespace>
     <UserSecretsId>46345736-a30f-4466-b3bb-42548ecfaacc</UserSecretsId>
   </PropertyGroup>

--- a/Applications/ConsoleReferenceServer/ConsoleUtils.cs
+++ b/Applications/ConsoleReferenceServer/ConsoleUtils.cs
@@ -43,7 +43,6 @@ using Opc.Ua.Configuration;
 using Serilog;
 using Serilog.Events;
 using Serilog.Templates;
-using static Opc.Ua.Utils;
 
 namespace Quickstarts
 {
@@ -62,34 +61,34 @@ namespace Quickstarts
         public override void WriteLine(char value)
         {
             m_builder.Append(value);
-            LogInfo("{0}", m_builder.ToString());
+            Utils.LogInfo("{0}", m_builder.ToString());
             m_builder.Clear();
         }
 
         public override void WriteLine()
         {
-            LogInfo("{0}", m_builder.ToString());
+            Utils.LogInfo("{0}", m_builder.ToString());
             m_builder.Clear();
         }
 
         public override void WriteLine(string format, object arg0)
         {
             m_builder.Append(format);
-            LogInfo(m_builder.ToString(), arg0);
+            Utils.LogInfo(m_builder.ToString(), arg0);
             m_builder.Clear();
         }
 
         public override void WriteLine(string format, object arg0, object arg1)
         {
             m_builder.Append(format);
-            LogInfo(m_builder.ToString(), arg0, arg1);
+            Utils.LogInfo(m_builder.ToString(), arg0, arg1);
             m_builder.Clear();
         }
 
         public override void WriteLine(string format, params object[] arg)
         {
             m_builder.Append(format);
-            LogInfo(m_builder.ToString(), arg);
+            Utils.LogInfo(m_builder.ToString(), arg);
             m_builder.Clear();
         }
 
@@ -101,7 +100,7 @@ namespace Quickstarts
         public override void WriteLine(string value)
         {
             m_builder.Append(value);
-            LogInfo("{0}", m_builder.ToString());
+            Utils.LogInfo("{0}", m_builder.ToString());
             m_builder.Clear();
         }
 
@@ -338,8 +337,8 @@ namespace Quickstarts
 
             // switch for Trace/Verbose output
             var traceMasks = configuration.TraceConfiguration.TraceMasks;
-            if ((traceMasks & ~(TraceMasks.Information | TraceMasks.Error |
-                TraceMasks.Security | TraceMasks.StartStop | TraceMasks.StackTrace)) != 0)
+            if ((traceMasks & ~(Utils.TraceMasks.Information | Utils.TraceMasks.Error |
+                Utils.TraceMasks.Security | Utils.TraceMasks.StartStop | Utils.TraceMasks.StackTrace)) != 0)
             {
                 fileLevel = LogLevel.Trace;
             }
@@ -350,7 +349,7 @@ namespace Quickstarts
             {
                 loggerConfiguration.WriteTo.File(
                     new ExpressionTemplate("{UtcDateTime(@t):yyyy-MM-dd HH:mm:ss.fff} [{@l:u3}] {@m}\n{@x}"),
-                    ReplaceSpecialFolderNames(outputFilePath),
+                    Utils.ReplaceSpecialFolderNames(outputFilePath),
                     restrictedToMinimumLevel: (LogEventLevel)fileLevel,
                     rollOnFileSizeLimit: true);
             }
@@ -371,7 +370,7 @@ namespace Quickstarts
                 .CreateLogger(context);
 
             // set logger interface, disables TraceEvent
-            SetLogger(logger);
+            Utils.SetLogger(logger);
         }
 
         /// <summary>
@@ -380,24 +379,24 @@ namespace Quickstarts
         public static void LogTest()
         {
             // print legacy logging output, for testing
-            Trace(TraceMasks.Error, "This is an Error message: {0}", TraceMasks.Error);
-            Trace(TraceMasks.Information, "This is a Information message: {0}", TraceMasks.Information);
-            Trace(TraceMasks.StackTrace, "This is a StackTrace message: {0}", TraceMasks.StackTrace);
-            Trace(TraceMasks.Service, "This is a Service message: {0}", TraceMasks.Service);
-            Trace(TraceMasks.ServiceDetail, "This is a ServiceDetail message: {0}", TraceMasks.ServiceDetail);
-            Trace(TraceMasks.Operation, "This is a Operation message: {0}", TraceMasks.Operation);
-            Trace(TraceMasks.OperationDetail, "This is a OperationDetail message: {0}", TraceMasks.OperationDetail);
-            Trace(TraceMasks.StartStop, "This is a StartStop message: {0}", TraceMasks.StartStop);
-            Trace(TraceMasks.ExternalSystem, "This is a ExternalSystem message: {0}", TraceMasks.ExternalSystem);
-            Trace(TraceMasks.Security, "This is a Security message: {0}", TraceMasks.Security);
+            Utils.Trace(Utils.TraceMasks.Error, "This is an Error message: {0}", Utils.TraceMasks.Error);
+            Utils.Trace(Utils.TraceMasks.Information, "This is a Information message: {0}", Utils.TraceMasks.Information);
+            Utils.Trace(Utils.TraceMasks.StackTrace, "This is a StackTrace message: {0}", Utils.TraceMasks.StackTrace);
+            Utils.Trace(Utils.TraceMasks.Service, "This is a Service message: {0}", Utils.TraceMasks.Service);
+            Utils.Trace(Utils.TraceMasks.ServiceDetail, "This is a ServiceDetail message: {0}", Utils.TraceMasks.ServiceDetail);
+            Utils.Trace(Utils.TraceMasks.Operation, "This is a Operation message: {0}", Utils.TraceMasks.Operation);
+            Utils.Trace(Utils.TraceMasks.OperationDetail, "This is a OperationDetail message: {0}", Utils.TraceMasks.OperationDetail);
+            Utils.Trace(Utils.TraceMasks.StartStop, "This is a StartStop message: {0}", Utils.TraceMasks.StartStop);
+            Utils.Trace(Utils.TraceMasks.ExternalSystem, "This is a ExternalSystem message: {0}", Utils.TraceMasks.ExternalSystem);
+            Utils.Trace(Utils.TraceMasks.Security, "This is a Security message: {0}", Utils.TraceMasks.Security);
 
             // print ILogger logging output
-            LogTrace("This is a Trace message: {0}", LogLevel.Trace);
-            LogDebug("This is a Debug message: {0}", LogLevel.Debug);
-            LogInfo("This is a Info message: {0}", LogLevel.Information);
-            LogWarning("This is a Warning message: {0}", LogLevel.Warning);
-            LogError("This is a Error message: {0}", LogLevel.Error);
-            LogCritical("This is a Critical message: {0}", LogLevel.Critical);
+            Utils.LogTrace("This is a Trace message: {0}", LogLevel.Trace);
+            Utils.LogDebug("This is a Debug message: {0}", LogLevel.Debug);
+            Utils.LogInfo("This is a Info message: {0}", LogLevel.Information);
+            Utils.LogWarning("This is a Warning message: {0}", LogLevel.Warning);
+            Utils.LogError("This is a Error message: {0}", LogLevel.Error);
+            Utils.LogCritical("This is a Critical message: {0}", LogLevel.Critical);
         }
 
         /// <summary>

--- a/Applications/ConsoleReferenceSubscriber/Program.cs
+++ b/Applications/ConsoleReferenceSubscriber/Program.cs
@@ -934,10 +934,12 @@ namespace Quickstarts.ConsoleReferenceSubscriber
         /// </summary>
         private static void InitializeLog()
         {
+#if TRACEEVENTLOGGER
             // Initialize logger
             Utils.SetTraceLog("%CommonApplicationData%\\OPC Foundation\\Logs\\Quickstarts.ConsoleReferenceSubscriber.log.txt", true);
             Utils.SetTraceMask(Utils.TraceMasks.Error);
             Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
+#endif
         }
         #endregion
     }

--- a/Fuzzing/common/Fuzz.Tools/Logging.cs
+++ b/Fuzzing/common/Fuzz.Tools/Logging.cs
@@ -35,7 +35,6 @@ using Opc.Ua;
 using Serilog;
 using Serilog.Events;
 using Serilog.Templates;
-using static Opc.Ua.Utils;
 
 public static class Logging
 {
@@ -78,7 +77,7 @@ public static class Logging
         {
             loggerConfiguration.WriteTo.File(
                 new ExpressionTemplate("{UtcDateTime(@t):yyyy-MM-dd HH:mm:ss.fff} [{@l:u3}] {@m}\n{@x}"),
-                ReplaceSpecialFolderNames(outputFilePath),
+                Utils.ReplaceSpecialFolderNames(outputFilePath),
                 restrictedToMinimumLevel: (LogEventLevel)fileLevel,
                 rollOnFileSizeLimit: true);
         }
@@ -99,7 +98,7 @@ public static class Logging
             .CreateLogger(context);
 
         // set logger interface, disables TraceEvent
-        SetLogger(logger);
+        Utils.SetLogger(logger);
     }
 
     private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs args)

--- a/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
+++ b/Stack/Opc.Ua.Core/Stack/Configuration/ApplicationConfiguration.cs
@@ -596,6 +596,7 @@ namespace Opc.Ua
         /// </summary>
         public void ApplySettings()
         {
+#if TRACEEVENTLOGGER
             Utils.SetTraceLog(m_outputFilePath, m_deleteOnLoad);
             Utils.SetTraceMask(m_traceMasks);
 
@@ -607,6 +608,7 @@ namespace Opc.Ua
             {
                 Utils.SetTraceOutput(Utils.TraceOutput.DebugAndFile);
             }
+#endif
         }
         #endregion
     }

--- a/Stack/Opc.Ua.Core/Types/Utils/TraceEventArgs.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TraceEventArgs.cs
@@ -12,6 +12,7 @@
 
 using System;
 
+#if TRACEEVENTLOGGER
 namespace Opc.Ua
 {
     /// <summary>
@@ -66,3 +67,4 @@ namespace Opc.Ua
         #endregion Public Properties
     }
 }
+#endif

--- a/Stack/Opc.Ua.Core/Types/Utils/TraceEventLogger.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/TraceEventLogger.cs
@@ -13,6 +13,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 
+#if TRACEEVENTLOGGER
 namespace Opc.Ua
 {
     /// <summary>
@@ -49,3 +50,4 @@ namespace Opc.Ua
         }
     }
 }
+#endif

--- a/Stack/Opc.Ua.Core/Types/Utils/Tracing.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Tracing.cs
@@ -12,6 +12,8 @@
 
 using System;
 
+#if TRACEEVENTLOGGER
+
 namespace Opc.Ua
 {
     /// <summary>
@@ -87,3 +89,4 @@ namespace Opc.Ua
         #endregion
     }
 }
+#endif

--- a/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
+++ b/Stack/Opc.Ua.Core/Types/Utils/Utils.cs
@@ -185,10 +185,14 @@ namespace Opc.Ua
 
         #region Trace Support
 #if DEBUG
+#if TRACEEVENTLOGGER
         private static int s_traceOutput = (int)TraceOutput.DebugAndFile;
+#endif
         private static int s_traceMasks = (int)TraceMasks.All;
 #else
+#if TRACEEVENTLOGGER
         private static int s_traceOutput = (int)TraceOutput.FileOnly;
+#endif
         private static int s_traceMasks = (int)TraceMasks.None;
 #endif
 
@@ -282,6 +286,7 @@ namespace Opc.Ua
             public const int All = 0x3FF;
         }
 
+#if TRACEEVENTLOGGER
         /// <summary>
         /// Sets the output for tracing (thread safe).
         /// </summary>
@@ -292,6 +297,7 @@ namespace Opc.Ua
                 s_traceOutput = (int)output;
             }
         }
+#endif
 
         /// <summary>
         /// Gets the current trace mask settings.
@@ -309,6 +315,7 @@ namespace Opc.Ua
             s_traceMasks = (int)masks;
         }
 
+#if TRACEEVENTLOGGER
         /// <summary>
         /// Returns Tracing class instance for event attaching.
         /// </summary>
@@ -441,6 +448,7 @@ namespace Opc.Ua
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Writes an informational message to the trace log.
@@ -536,6 +544,7 @@ namespace Opc.Ua
             return message;
         }
 
+#if TRACEEVENTLOGGER
         /// <summary>
         /// Writes an exception/error message to the trace log.
         /// </summary>
@@ -546,6 +555,7 @@ namespace Opc.Ua
             // trace message.
             Trace(e, (int)TraceMasks.Error, message.ToString(), handled, null);
         }
+#endif
 
         /// <summary>
         /// Writes a message to the trace log.
@@ -576,6 +586,7 @@ namespace Opc.Ua
             Trace(null, traceMask, format, handled, args);
         }
 
+#if TRACEEVENTLOGGER
         /// <summary>
         /// Writes a message to the trace log.
         /// </summary>
@@ -656,6 +667,7 @@ namespace Opc.Ua
 
             TraceWriteLine(message.ToString());
         }
+#endif
         #endregion
 
         #region File Access

--- a/Tests/Opc.Ua.Core.Tests/Types/Utils/LogTests.cs
+++ b/Tests/Opc.Ua.Core.Tests/Types/Utils/LogTests.cs
@@ -34,6 +34,7 @@ using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
+#if TRACEEVENTLOGGER
 
 namespace Opc.Ua.Core.Tests.Types.LogTests
 {
@@ -305,3 +306,4 @@ namespace Opc.Ua.Core.Tests.Types.LogTests
         }
     }
 }
+#endif

--- a/Tests/Opc.Ua.Server.Tests/NUnitTestLogger.cs
+++ b/Tests/Opc.Ua.Server.Tests/NUnitTestLogger.cs
@@ -50,7 +50,9 @@ namespace Opc.Ua.Server.Tests
 
             // disable the built in tracing, use nunit trace output
             Utils.SetTraceMask(Utils.TraceMask & Utils.TraceMasks.StackTrace);
+#if TRACEEVENTLOGGER
             Utils.SetTraceOutput(Utils.TraceOutput.Off);
+#endif
             Utils.SetLogger(traceLogger);
 
             return traceLogger;

--- a/Tests/Opc.Ua.Server.Tests/NUnitTraceLogger.cs
+++ b/Tests/Opc.Ua.Server.Tests/NUnitTraceLogger.cs
@@ -27,6 +27,7 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+#if TRACEEVENTLOGGER
 using System;
 using System.Globalization;
 using System.IO;
@@ -91,3 +92,4 @@ namespace Opc.Ua.Server.Tests
         }
     }
 }
+#endif


### PR DESCRIPTION
## Proposed changes

The trace event callback support is removed. Instead support only Ilogger/ILoggerFactory.

By default the logger is now a NullLogger.